### PR TITLE
Depend only on installation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ org_*.h
 *.log
 target/*
 *.dSYM/
+*~
+.metadata

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,15 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>6.2</version>
             </plugin>

--- a/src/main/native/org/ofi/libjfabric_native/av_type.c
+++ b/src/main/native/org/ofi/libjfabric_native/av_type.c
@@ -1,5 +1,5 @@
 #include "org_ofi_libjfabric_enums_AVType.h"
-#include "fabric.h"
+#include "libfabric.h"
 
 JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_enums_AVType_getUNSPEC(JNIEnv *env, jclass jthis) {
 	return FI_AV_UNSPEC;

--- a/src/main/native/org/ofi/libjfabric_native/domain_attr.c
+++ b/src/main/native/org/ofi/libjfabric_native/domain_attr.c
@@ -1,4 +1,3 @@
-#include "fabric.h"
 #include "org_ofi_libjfabric_attributes_DomainAttr.h"
 #include "libfabric.h"
 

--- a/src/main/native/org/ofi/libjfabric_native/ep_attr.c
+++ b/src/main/native/org/ofi/libjfabric_native/ep_attr.c
@@ -1,5 +1,4 @@
 #include "org_ofi_libjfabric_attributes_EndPointAttr.h"
-#include "fabric.h"
 #include "libfabric.h"
 
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_EndPointAttr_initEndPointAttr

--- a/src/main/native/org/ofi/libjfabric_native/ep_type.c
+++ b/src/main/native/org/ofi/libjfabric_native/ep_type.c
@@ -1,5 +1,5 @@
 #include "org_ofi_libjfabric_enums_EPType.h"
-#include "fabric.h"
+#include "libfabric.h"
 
 JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_enums_EPType_getUNSPEC(JNIEnv *env, jclass jthis) {
 	return FI_EP_UNSPEC;

--- a/src/main/native/org/ofi/libjfabric_native/fabric_attr.c
+++ b/src/main/native/org/ofi/libjfabric_native/fabric_attr.c
@@ -1,5 +1,4 @@
 #include "org_ofi_libjfabric_attributes_FabricAttr.h"
-#include "fabric.h"
 #include "libfabric.h"
 
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_FabricAttr_initFabricAttr

--- a/src/main/native/org/ofi/libjfabric_native/info.c
+++ b/src/main/native/org/ofi/libjfabric_native/info.c
@@ -1,4 +1,3 @@
-#include "fabric.h"
 #include "org_ofi_libjfabric_Info.h"
 #include "libfabric.h"
 

--- a/src/main/native/org/ofi/libjfabric_native/jfabric.h
+++ b/src/main/native/org/ofi/libjfabric_native/jfabric.h
@@ -1,7 +1,7 @@
 #ifndef _JFABRIC_H_
 #define _JFABRIC_H_
 
-#include "fabric.h"
+#include "rdma/fabric.h"
 
 int getLinkedListLength(struct fi_info **resultInfo);
 

--- a/src/main/native/org/ofi/libjfabric_native/libfabric.h
+++ b/src/main/native/org/ofi/libjfabric_native/libfabric.h
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <dlfcn.h>
 
-#include "fabric.h"
+#include "rdma/fabric.h"
 #include "org_ofi_libjfabric_LibFabric.h"
 
 

--- a/src/main/native/org/ofi/libjfabric_native/makefile
+++ b/src/main/native/org/ofi/libjfabric_native/makefile
@@ -2,8 +2,8 @@
 # Maven sets JAVA_HOME aka java.home to ${JAVA_HOME}/jre.  Need to add a funky include for this.
 #
 
-CFLAGS=-g -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I/home/nathan/libfabric-cray/include/rdma \
-	-I/home/nathan/libfabric-cray/include
+CFLAGS=-g -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux \
+	   -I/home/nathan/libfab_install/include
 
 LIBFAB_LIB_LOCATION=/home/nathan/libfab_install/lib
 

--- a/src/main/native/org/ofi/libjfabric_native/mr_mode.c
+++ b/src/main/native/org/ofi/libjfabric_native/mr_mode.c
@@ -1,5 +1,5 @@
 #include "org_ofi_libjfabric_enums_MRMode.h"
-#include "fabric.h"
+#include "libfabric.h"
 
 JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_enums_MRMode_getUNSPEC(JNIEnv *env, jclass jthis) {
 	return FI_MR_UNSPEC;

--- a/src/main/native/org/ofi/libjfabric_native/progress.c
+++ b/src/main/native/org/ofi/libjfabric_native/progress.c
@@ -1,5 +1,5 @@
 #include "org_ofi_libjfabric_enums_Progress.h"
-#include "fabric.h"
+#include "libfabric.h"
 
 JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_enums_Progress_getUNSPEC(JNIEnv *env, jclass jthis) {
 	return FI_PROGRESS_UNSPEC;

--- a/src/main/native/org/ofi/libjfabric_native/protocol.c
+++ b/src/main/native/org/ofi/libjfabric_native/protocol.c
@@ -1,5 +1,5 @@
 #include "org_ofi_libjfabric_enums_Protocol.h"
-#include "fabric.h"
+#include "libfabric.h"
 
 JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_enums_Protocol_getUNSPEC(JNIEnv *env, jclass jthis) {
 	return FI_PROTO_UNSPEC;

--- a/src/main/native/org/ofi/libjfabric_native/receive_attr.c
+++ b/src/main/native/org/ofi/libjfabric_native/receive_attr.c
@@ -1,5 +1,4 @@
 #include "org_ofi_libjfabric_attributes_ReceiveAttr.h"
-#include "fabric.h"
 #include "libfabric.h"
 
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_ReceiveAttr_initReceiveAttr

--- a/src/main/native/org/ofi/libjfabric_native/resource_mgmt.c
+++ b/src/main/native/org/ofi/libjfabric_native/resource_mgmt.c
@@ -1,5 +1,5 @@
 #include "org_ofi_libjfabric_enums_ResourceMgmt.h"
-#include "fabric.h"
+#include "libfabric.h"
 
 JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_enums_ResourceMgmt_getUNSPEC(JNIEnv *env, jclass jthis) {
 	return FI_RM_UNSPEC;

--- a/src/main/native/org/ofi/libjfabric_native/specified_domain_attr.c
+++ b/src/main/native/org/ofi/libjfabric_native/specified_domain_attr.c
@@ -1,5 +1,4 @@
 #include "org_ofi_libjfabric_attributes_SpecifiedDomainAttr.h"
-#include "fabric.h"
 #include "libfabric.h"
 
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_SpecifiedDomainAttr_initWithDomain

--- a/src/main/native/org/ofi/libjfabric_native/specified_fabric_attr.c
+++ b/src/main/native/org/ofi/libjfabric_native/specified_fabric_attr.c
@@ -1,5 +1,4 @@
 #include "org_ofi_libjfabric_attributes_SpecifiedFabricAttr.h"
-#include "fabric.h"
 #include "libfabric.h"
 
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_SpecifiedFabricAttr_initWithFabric

--- a/src/main/native/org/ofi/libjfabric_native/threading.c
+++ b/src/main/native/org/ofi/libjfabric_native/threading.c
@@ -1,5 +1,5 @@
 #include "org_ofi_libjfabric_enums_Threading.h"
-#include "fabric.h"
+#include "libfabric.h"
 
 JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_enums_Threading_getUNSPEC(JNIEnv *env, jclass jthis) {
 	return FI_THREAD_UNSPEC;

--- a/src/main/native/org/ofi/libjfabric_native/tx_attr.c
+++ b/src/main/native/org/ofi/libjfabric_native/tx_attr.c
@@ -1,5 +1,4 @@
 #include "org_ofi_libjfabric_attributes_TransmitAttr.h"
-#include "fabric.h"
 #include "libfabric.h"
 
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_TransmitAttr_initTransmitAttr


### PR DESCRIPTION
This commit removes some places where the project
would attempt to use non-installation files which
may not be on an end user's computer. It also
includes an update to the pom.xml to force the
use of java 8.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov

@hppritcha  You will want to pull this change for your cmake stuff.
