### PR TITLE
Updated getInfo and added FI_SOURCE

### DIFF
--- a/src/main/java/org/ofi/libjfabric/Constant.java
+++ b/src/main/java/org/ofi/libjfabric/Constant.java
@@ -35,6 +35,7 @@ package org.ofi.libjfabric;
 //used to init constants based on their values in libfabric
 public class Constant {
 	protected long FI_LOCAL_MR;
+	protected long FI_SOURCE;
 	
 	protected Constant() {
 		setConstant();

--- a/src/main/java/org/ofi/libjfabric/LibFabric.java
+++ b/src/main/java/org/ofi/libjfabric/LibFabric.java
@@ -37,6 +37,7 @@ import java.nio.*;
 public class LibFabric {
 	private static final ByteOrder nativeOrder = ByteOrder.nativeOrder();
 	public static final long FI_LOCAL_MR;
+	public static final long FI_SOURCE;
 
 	static {
 		System.loadLibrary("jfab_native");
@@ -44,6 +45,7 @@ public class LibFabric {
 		Constant c = new Constant();
 		
 		FI_LOCAL_MR = c.FI_LOCAL_MR;
+		FI_SOURCE = c.FI_SOURCE;
 	}
 	
 	public static void loadVerbose() {
@@ -92,12 +94,27 @@ public class LibFabric {
 
 	public static Info[] getInfo(Version version, String node, String service, long flags, Info hints) {
 		long infoHandleArray[] = null;
-
-		if(hints != null) {
-			infoHandleArray = getInfoJNI(version.getMajorVersion(), version.getMinorVersion(), node, service, flags, hints.getHandle());
-		} else {
-			infoHandleArray = getInfoJNI(version.getMajorVersion(), version.getMinorVersion(), node, service, flags, 0);
+		
+		infoHandleArray = getInfoJNI(version.getMajorVersion(), version.getMinorVersion(), node, service, flags, hints.getHandle());
+		
+		if(infoHandleArray == null) {
+			return null; //should probably handle this better
 		}
+
+		Info infoArray[] = new Info[infoHandleArray.length];
+
+		for(int i = 0; i < infoHandleArray.length; i++) {
+			infoArray[i] = new Info(infoHandleArray[i]);
+		}
+
+		return infoArray;
+	}
+	
+	public static Info[] getInfo(Version version, String node, String service, long flags) {
+		long infoHandleArray[] = null;
+
+		infoHandleArray = getInfoJNI(version.getMajorVersion(), version.getMinorVersion(), node, service, flags, 0);
+
 		if(infoHandleArray == null) {
 			return null; //should probably handle this better
 		}

--- a/src/main/native/org/ofi/libjfabric_native/constant.c
+++ b/src/main/native/org/ofi/libjfabric_native/constant.c
@@ -43,6 +43,14 @@ void setLongField(JNIEnv *env, jclass c, jobject jthis, char *field, jlong value
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_Constant_setConstant
 	(JNIEnv *env, jobject jthis)
 {
+<<<<<<< Updated upstream
 	jclass c = (*env)->GetObjectClass(env, jthis);
 	setLongField(env, c, jthis, "FI_LOCAL_MR", FI_LOCAL_MR);
 }
+=======
+	jclass c = (*env)->GetObjectClass(env, obj);
+	
+	setStaticLongField(env, c, obj, "FI_LOCAL_MR", FI_LOCAL_MR);
+	setStaticLongField(env, c, obj, "FI_SOURCE", FI_SOURCE);
+}
+>>>>>>> Stashed changes

--- a/src/test/java/org/ofi/libjfabrictests/TestLibFabric.java
+++ b/src/test/java/org/ofi/libjfabrictests/TestLibFabric.java
@@ -49,7 +49,7 @@ public class TestLibFabric {
 	public void testGetInfo() {
 		Version version = new Version(1, 3);
 		
-		Info resultInfo[] = LibFabric.getInfo(version, null, null, 0, null);
+		Info resultInfo[] = LibFabric.getInfo(version, null, null, 0);
 		
 		assert resultInfo != null;
 		


### PR DESCRIPTION
Updated getInfo to include a method call that does not require
and info object.  This is a much cleaner way to handle the way
you can pass null in the C version of libfabric.

Also added the FI_SOURCE constant which is needed in the pingpong
test.

This commit also includes the most recent changes to the pingpong
test to create a more recent backup copy.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
