### PR TITLE
Add additional Fabric constructor

### DIFF
--- a/src/main/java/org/ofi/libjfabric/Fabric.java
+++ b/src/main/java/org/ofi/libjfabric/Fabric.java
@@ -47,6 +47,12 @@ public class Fabric extends FIDescriptor {
 	}
 	private native long initFabric(long fabricAttrHandle, long contextHandle);
 	
+	public Fabric(FabricAttr fabricAttr) {
+		this.fabricAttr = fabricAttr;
+		this.handle = initFabric2(fabricAttr.getHandle());
+	}
+	private native long initFabric2(long fabricAttrHandle);
+	
 	public Fabric(long handle) {
 		super(handle);
 	}

--- a/src/main/native/org/ofi/libjfabric_native/constant.c
+++ b/src/main/native/org/ofi/libjfabric_native/constant.c
@@ -43,8 +43,8 @@ void setLongField(JNIEnv *env, jclass c, jobject jthis, char *field, jlong value
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_Constant_setConstant
 	(JNIEnv *env, jobject jthis)
 {
-	jclass c = (*env)->GetObjectClass(env, obj);
+	jclass c = (*env)->GetObjectClass(env, jthis);
 	
-	setStaticLongField(env, c, obj, "FI_LOCAL_MR", FI_LOCAL_MR);
-	setStaticLongField(env, c, obj, "FI_SOURCE", FI_SOURCE);
+	setLongField(env, c, jthis, "FI_LOCAL_MR", FI_LOCAL_MR);
+	setLongField(env, c, jthis, "FI_SOURCE", FI_SOURCE);
 }

--- a/src/main/native/org/ofi/libjfabric_native/fabric.c
+++ b/src/main/native/org/ofi/libjfabric_native/fabric.c
@@ -50,6 +50,23 @@ JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_initFabric
 	return (jlong)fabric;
 }
 
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_initFabric2
+	(JNIEnv *env, jobject jthis, jlong fabricAttrHandle)
+{
+	struct fid_fabric *fabric = (struct fid_fabric *)calloc(1, sizeof(struct fid_fabric));
+
+	fabric_list[fabric_list_tail] = fabric;
+	fabric_list_tail++;
+
+	int res = fi_fabric((struct fi_fabric_attr *)fabricAttrHandle, &fabric, NULL);
+
+	if(res) {
+		printf("Error creating fabric: %d\n", res);
+		exit(1);
+	}
+	return (jlong)fabric;
+}
+
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_createDomainJNI
 	(JNIEnv *env, jobject jthis, jlong fabricHandle, jlong infoHandle, jlong contextHandle)
 {


### PR DESCRIPTION
Added an additional constructor for Fabric that
does not require a context object to cover the
use case in the C version where a null can be
entered for context.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
