### PR TITLE
Add additional event queue constructor

### DIFF
--- a/src/main/java/org/ofi/libjfabric/Fabric.java
+++ b/src/main/java/org/ofi/libjfabric/Fabric.java
@@ -72,6 +72,11 @@ public class Fabric extends FIDescriptor {
 	}
 	private native long eventQueueOpen(long fabricHandle, long eventQueueAttrHandle, long contextHandle);
 	
+	public EventQueue eventQueueOpen(EventQueueAttr eventQueueAttr) {
+		return new EventQueue(eventQueueOpen2(this.handle, eventQueueAttr.getHandle()));
+	}
+	private native long eventQueueOpen2(long fabricHandle, long eventQueueAttrHandle);
+	
 	public Wait waitOpen(WaitAttr waitAttr) {
 		return new Wait(waitOpen(this.handle, waitAttr.getHandle()));
 	}

--- a/src/main/native/org/ofi/libjfabric_native/fabric.c
+++ b/src/main/native/org/ofi/libjfabric_native/fabric.c
@@ -121,6 +121,24 @@ JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_eventQueueOpen
 	return (jlong)event_queue;
 }
 
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_eventQueueOpen2
+	(JNIEnv *env, jobject jthis, jlong fabricHandle, jlong eqAttrHandle)
+{
+	struct fid_eq *event_queue = (struct fid_eq *)calloc(1, sizeof(struct fid_eq));
+
+	event_queue_list[event_queue_list_tail] = event_queue;
+	event_queue_list_tail++;
+
+	int res = ((struct fid_fabric *)fabricHandle)->ops->eq_open((struct fid_fabric *)fabricHandle,
+			(struct fi_eq_attr *)eqAttrHandle, &event_queue, NULL);
+
+	if(res) {
+		printf("Error opening event queue: %d\n", res);
+		exit(1);
+	}
+	return (jlong)event_queue;
+}
+
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_waitOpen
 	(JNIEnv *env, jobject jthis, jlong fabricHandle, jlong waitAttrHandle)
 {


### PR DESCRIPTION
Added an additional event queue creation method that
does not take a context object to cover the use case
in the C code of entering NULL for the context.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
