### PR TITLE
Add additional pep constructor

### DIFF
--- a/src/main/java/org/ofi/libjfabric/Fabric.java
+++ b/src/main/java/org/ofi/libjfabric/Fabric.java
@@ -67,6 +67,11 @@ public class Fabric extends FIDescriptor {
 	}
 	private native long createPassiveEP(long fabricHandle, long infoHandle, long contextHandle);
 	
+	public PassiveEndPoint createPassiveEndPoint(Info info) {
+		return new PassiveEndPoint(createPassiveEP2(this.handle, info.getHandle()));
+	}
+	private native long createPassiveEP2(long fabricHandle, long infoHandle);
+	
 	public EventQueue eventQueueOpen(EventQueueAttr eventQueueAttr, Context context) {
 		return new EventQueue(eventQueueOpen(this.handle, eventQueueAttr.getHandle(), context.getHandle()));
 	}

--- a/src/main/native/org/ofi/libjfabric_native/fabric.c
+++ b/src/main/native/org/ofi/libjfabric_native/fabric.c
@@ -103,6 +103,24 @@ JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_createPassiveEP
 	return (jlong)passive_ep;
 }
 
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_createPassiveEP2
+	(JNIEnv *env, jobject jthis, jlong fabricHandle, jlong infoHandle)
+{
+	struct fid_pep *passive_ep = (struct fid_pep *)calloc(1, sizeof(struct fid_pep));
+
+	passive_ep_list[passive_ep_list_tail] = passive_ep;
+	passive_ep_list_tail++;
+
+	int res = ((struct fid_fabric *)fabricHandle)->ops->passive_ep((struct fid_fabric *)fabricHandle,
+			(struct fi_info *)infoHandle, &passive_ep, NULL);
+
+	if(res) {
+		printf("Error creating passive endpoint: %d\n", res);
+		exit(1);
+	}
+	return (jlong)passive_ep;
+}
+
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_eventQueueOpen
 	(JNIEnv *env, jobject jthis, jlong fabricHandle, jlong eqAttrHandle, jlong contextHandle)
 {


### PR DESCRIPTION
Add an additional passive end point construction
method to cover the use case in the C code of
entering a NULL for the context object

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
