### PR TITLE
Add setDestAddr to Info Object

### DIFF
--- a/src/main/java/org/ofi/libjfabric/EndPointSharedOps.java
+++ b/src/main/java/org/ofi/libjfabric/EndPointSharedOps.java
@@ -37,4 +37,9 @@ public class EndPointSharedOps extends FIDescriptor { //TODO: find a better name
 	public EndPointSharedOps(long handle) {
 		super(handle);
 	}
+	
+	public String getName() {
+		return getName(this.handle);
+	}
+	private native String getName(long handle);
 }

--- a/src/main/java/org/ofi/libjfabric/Info.java
+++ b/src/main/java/org/ofi/libjfabric/Info.java
@@ -165,4 +165,8 @@ public class Info {
 	}
 	private native void setFabricAttr(long fabricAttrHandle, long thisHandle);
 
+	public void setDestAddr(String destAddr) {  //NOTE: Only added a set for this one because I am just coding to the PingPongTest at this point.
+		setDestAddr(destAddr, this.handle);
+	}
+	private native void setDestAddr(String destAddr, long infoHandle);
 }

--- a/src/main/native/org/ofi/libjfabric_native/info.c
+++ b/src/main/native/org/ofi/libjfabric_native/info.c
@@ -198,3 +198,10 @@ JNIEXPORT void JNICALL Java_org_ofi_libjfabric_Info_setFabricAttr
 {
 	((struct fi_info*)thisHandle)->fabric_attr = (struct fi_fabric_attr*)fabricAttrHandle;
 }
+
+JNIEXPORT void JNICALL Java_org_ofi_libjfabric_Info_setDestAddr  //TODO: Ask Howard about this
+	(JNIEnv *env, jobject jthis, jstring destAddr, jlong thisHandle)
+{
+	const char *addr = (*env)->GetStringUTFChars(env, destAddr, NULL);
+	((struct fi_info*)thisHandle)->dest_addr = (void *)*addr;
+}

--- a/src/test/java/org/ofi/libjfabrictests/PingPongTest.java
+++ b/src/test/java/org/ofi/libjfabrictests/PingPongTest.java
@@ -306,62 +306,48 @@ public class PingPongTest {
 			System.err.printf("\"\n");
 		}
 	}
-	/* TODO: was working here
-private void pp_send_name(CTPingPong ct, *endpoint)
-{
+	
+private void pp_send_name(CTPingPong ct, EndPointSharedOps endpoint) {
 	String local_name;
-	long addrlen;
-	int len;
+	//long addrlen;
+	//int len;
 
 	PP_DEBUG("Fetching local address\n");
+	
+	local_name = endpoint.getName();
 
-	fi_getname(endpoint, local_name, &addrlen);
-
-	PP_DEBUG("Sending name length\n");
-	len = htonl(addrlen);
-	pp_ctrl_send(ct, len);
+	//PP_DEBUG("Sending name length\n");
+	
+	//pp_ctrl_send(ct, local_name.length()); sending name length, think i can skip this in Java
 
 	PP_DEBUG("Sending name\n");
-	pp_ctrl_send(ct, local_name, addrlen);
+	pp_ctrl_send(ct, local_name.getBytes());
 	PP_DEBUG("Sent name\n");
 }
 
-int pp_recv_name(struct ct_pingpong *ct)
-{
-	uint32_t len;
-	int ret;
+private void pp_recv_name(CTPingPong ct) {
 
-	PP_DEBUG("Receiving name length\n");
-	ret = pp_ctrl_recv(ct, (char *) &len, sizeof(len));
-	if (ret < 0)
-		return ret;
+	//PP_DEBUG("Receiving name length\n");
+	//pp_ctrl_recv(ct, (char *) &len, sizeof(len));
+	
+	//len = ntohl(len);
 
-	len = ntohl(len);
-
-	if (len > sizeof(ct->rem_name)) {
-		PP_DEBUG("Address length exceeds address storage\n");
-		return -EMSGSIZE;
-	}
+	//if (len > sizeof(ct->rem_name)) {
+	//	PP_DEBUG("Address length exceeds address storage\n");
+	//	return -EMSGSIZE;
+	//}
 
 	PP_DEBUG("Receiving name\n");
-	ret = pp_ctrl_recv(ct, ct->rem_name, len);
-	if (ret < 0)
-		return ret;
+	pp_ctrl_recv(ct, ct.rem_name);
+	
 	PP_DEBUG("Received name\n");
 
-	ct->hints->dest_addr = malloc(len);
-	if (!ct->hints->dest_addr) {
-		PP_DEBUG("Failed to allocate memory for destination address\n");
-		return -ENOMEM;
-	}
-
-	/* fi_freeinfo will free the dest_addr field. *
-	memcpy(ct->hints->dest_addr, ct->rem_name, len);
-	ct->hints->dest_addrlen = len;
-
-	return 0;
+	/* fi_freeinfo will free the dest_addr field. */
+	ct.hints.setDestAddr(ct.rem_name.toString());
+	
+	ct.hints.setDestAddrLen(ct.rem_name.length);
 }
-	 */
+
 	private void pp_ctrl_finish(CTPingPong ct) {
 		if (!ct.ctrl_connfd.isClosed()) {
 			try {


### PR DESCRIPTION
Added the setDestAddr method to the Info Object.

Also added the getName method to EndPointSharedOps.
This commit also includes changes to the ping pong test
that prompted these changes.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
