### PR TITLE
Add additional Constructors with no Context field

### DIFF
--- a/src/main/java/org/ofi/libjfabric/Domain.java
+++ b/src/main/java/org/ofi/libjfabric/Domain.java
@@ -50,10 +50,15 @@ public class Domain extends FIDescriptor {
 		throw new UnsupportedOperationException("Not implemented yet!");
 	}
 	
-	public EndPoint endPointOpen(Info info, Context context) {
-		return new EndPoint(endPointOpen(this.handle, info.getHandle(), context.getHandle()));
+	public EndPoint epOpen(Info info, Context context) {
+		return new EndPoint(epOpen(this.handle, info.getHandle(), context.getHandle()));
 	}
-	private native long endPointOpen(long domHandle, long infoHandle, long contextHandle);
+	private native long epOpen(long domHandle, long infoHandle, long contextHandle);
+	
+	public EndPoint epOpen(Info info) {
+		return new EndPoint(epOpen(this.handle, info.getHandle()));
+	}
+	private native long epOpen(long domHandle, long infoHandle);
 	
 	public ScalableEP scalableEPOpen(Info info, Context context) {
 		throw new UnsupportedOperationException("Not implemented yet!");

--- a/src/main/java/org/ofi/libjfabric/Fabric.java
+++ b/src/main/java/org/ofi/libjfabric/Fabric.java
@@ -58,9 +58,14 @@ public class Fabric extends FIDescriptor {
 	}
 	
 	public Domain createDomain(Info info, Context context) {
-		return new Domain(createDomainJNI(this.handle, info.getHandle(), context.getHandle()));
+		return new Domain(createDomain(this.handle, info.getHandle(), context.getHandle()));
 	}
-	private native long createDomainJNI(long fabricHandle, long infoHandle, long contextHandle);
+	private native long createDomain(long fabricHandle, long infoHandle, long contextHandle);
+	
+	public Domain createDomain(Info info) {
+		return new Domain(createDomain2(this.handle, info.getHandle()));
+	}
+	private native long createDomain2(long fabricHandle, long infoHandle);
 	
 	public PassiveEndPoint createPassiveEndPoint(Info info, Context context) {
 		return new PassiveEndPoint(createPassiveEP(this.handle, info.getHandle(), context.getHandle()));

--- a/src/main/native/org/ofi/libjfabric_native/domain.c
+++ b/src/main/native/org/ofi/libjfabric_native/domain.c
@@ -33,7 +33,7 @@
 #include "org_ofi_libjfabric_Fabric.h"
 #include "libfabric.h"
 
-JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Domain_endPointOpen
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Domain_epOpen
 	(JNIEnv *env, jobject jthis, jlong domHandle, jlong infoHandle, jlong contextHandle)
 {
 	struct fid_ep *endPoint = (struct fid_ep *)calloc(1, sizeof(struct fid_ep));
@@ -49,4 +49,22 @@ JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Domain_endPointOpen
 		exit(1);
 	}
 	return (jlong)endPoint;
+}
+
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Domain_epOpen
+	(JNIEnv *env, jobject jthis, jlong domHandle, jlong infoHandle)
+{
+struct fid_ep *endPoint = (struct fid_ep *)calloc(1, sizeof(struct fid_ep));
+
+ep_list[ep_list_tail] = endPoint;
+ep_list_tail++;
+
+int res = ((struct fid_domain *)domHandle)->ops->endpoint((struct fid_domain *)domHandle,
+		(struct fi_info *)infoHandle, &endPoint, NULL);
+
+if(res) {
+	printf("Error opening endPoint: %d\n", res);
+	exit(1);
+}
+return (jlong)endPoint;
 }

--- a/src/main/native/org/ofi/libjfabric_native/fabric.c
+++ b/src/main/native/org/ofi/libjfabric_native/fabric.c
@@ -67,7 +67,7 @@ JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_initFabric2
 	return (jlong)fabric;
 }
 
-JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_createDomainJNI
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_createDomain
 	(JNIEnv *env, jobject jthis, jlong fabricHandle, jlong infoHandle, jlong contextHandle)
 {
 	struct fid_domain *domain = (struct fid_domain *)calloc(1, sizeof(struct fid_domain));
@@ -82,6 +82,24 @@ JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_createDomainJNI
 			printf("Error creating domain: %d\n", res);
 			exit(1);
 		}
+	return (jlong)domain;
+}
+
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Fabric_createDomain2
+	(JNIEnv *env, jobject jthis, jlong fabricHandle, jlong infoHandle)
+{
+	struct fid_domain *domain = (struct fid_domain *)calloc(1, sizeof(struct fid_domain)); //TODO: do i need to calloc this or does libfabric do it for me?
+
+	domain_list[domain_list_tail] = domain;
+	domain_list_tail++;
+
+	int res = ((struct fid_fabric *)fabricHandle)->ops->domain((struct fid_fabric *)fabricHandle,
+			(struct fi_info *)infoHandle, &domain, NULL);
+
+	if(res) {
+		printf("Error creating domain: %d\n", res);
+		exit(1);
+	}
 	return (jlong)domain;
 }
 


### PR DESCRIPTION
Added additional constructors that do not require Context
objects.  This commit also includes some method renames so
the methods better match the rest of the code, and the
changes to the ping pong test that prompted the changes
to the bindings.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
