### PR TITLE
Added the mrRegister method to Domain

### DIFF
--- a/src/main/java/org/ofi/libjfabric/Constant.java
+++ b/src/main/java/org/ofi/libjfabric/Constant.java
@@ -40,6 +40,7 @@ public class Constant {
 	protected long FI_MSG;
 	protected long FI_TRANSMIT;
 	protected long FI_RECV;
+	protected long FI_SEND;
 	
 	protected Constant() {
 		setConstant();

--- a/src/main/java/org/ofi/libjfabric/Domain.java
+++ b/src/main/java/org/ofi/libjfabric/Domain.java
@@ -32,6 +32,7 @@
 
 package org.ofi.libjfabric;
 
+import java.nio.ByteBuffer;
 import org.ofi.libjfabric.attributes.AVAttr;
 import org.ofi.libjfabric.attributes.CQAttr;
 import org.ofi.libjfabric.attributes.CntrAttr;
@@ -67,6 +68,21 @@ public class Domain extends FIDescriptor {
 	public Counter cntrOpen(CntrAttr cntrAttr, Context context) {
 		throw new UnsupportedOperationException("Not implemented yet!");
 	}
+	//NOTE: should be able to duplicate offset with the slice method of ByteBuffer
+	public MemoryRegion mrRegister(ByteBuffer buf, long access, long offset, long requestedKey, long flags, Context context) {
+		throw new UnsupportedOperationException("Not implemented yet!");
+	}
 	
-	//public Poll pollOpen(PollAttr pollAttr, ) Will have to discuss how to implement this.
+	public MemoryRegion mrRegister(ByteBuffer buf, long access, long offset, long requestedKey, long flags) {
+			throw new UnsupportedOperationException("Not implemented yet!");
+	}
+	
+	public MemoryRegion mrRegister(ByteBuffer buf, long access, long offset, long flags) {
+		throw new UnsupportedOperationException("Not implemented yet!");
+	}
+	
+	public MemoryRegion mrRegister(ByteBuffer buf, long access, long requestedKey) {
+		return new MemoryRegion(mrRegister(this.handle, buf, buf.capacity(), access, requestedKey));
+	}
+	private native long mrRegister(long domainHandle, ByteBuffer buf, long length, long access, long requestedKey);
 }

--- a/src/main/java/org/ofi/libjfabric/LibFabric.java
+++ b/src/main/java/org/ofi/libjfabric/LibFabric.java
@@ -42,6 +42,7 @@ public class LibFabric {
 	public static final long FI_MSG;
 	public static final long FI_TRANSMIT;
 	public static final long FI_RECV;
+	public static final long FI_SEND;
 
 	static {
 		System.loadLibrary("jfab_native");
@@ -54,6 +55,7 @@ public class LibFabric {
 		FI_MSG = c.FI_MSG;
 		FI_TRANSMIT = c.FI_TRANSMIT;
 		FI_RECV = c.FI_RECV;
+		FI_SEND = c.FI_SEND;
 	}
 	
 	public static void loadVerbose() {

--- a/src/main/java/org/ofi/libjfabric/attributes/DomainAttr.java
+++ b/src/main/java/org/ofi/libjfabric/attributes/DomainAttr.java
@@ -38,17 +38,17 @@ public class DomainAttr {
 	protected long handle;
 	
 	public DomainAttr(String name, Threading threading, Progress cntrlProgress, Progress dataProgress, 
-			ResourceMgmt resourceMgmt, AVType avType, MRMode mrMode, int mrKeySize, int cqDataSize, int cqCnt, 
-			int endpointCount, int txCtxCnt, int rxCtxCnt, int maxEpTxCtx, int maxEpRxCtx, int maxEpStxCtx, int maxEpSrxCtx) 
+			ResourceMgmt resourceMgmt, AVType avType, MRMode mrMode, long mrKeySize, long cqDataSize, long cqCnt, 
+			long endpointCount, long txCtxCnt, long rxCtxCnt, long maxEpTxCtx, long maxEpRxCtx, long maxEpStxCtx, long maxEpSrxCtx) 
 	{
 		this.handle = initDomainAttr(name, threading.getVal(), cntrlProgress.getVal(), dataProgress.getVal(), 
 				resourceMgmt.getVal(), avType.getVal(), mrMode.getVal(), mrKeySize, cqDataSize, cqCnt, endpointCount, 
 				txCtxCnt, rxCtxCnt, maxEpTxCtx, maxEpRxCtx, maxEpStxCtx, maxEpSrxCtx);
 	}
 	
-	private native long initDomainAttr(String name, int threading, int cntrlProgress, int dataProgress, 
-			int resourceMgmt, int avType, int mrMode, int mrKeySize, int cqDataSize, int cqCnt, 
-			int endpointCount, int txCtxCnt, int rxCtxCnt, int maxEpTxCtx, int maxEpRxCtx, int maxEpStxCtx, int maxEpSrxCtx);
+	private native long initDomainAttr(String name, long threading, long cntrlProgress, long dataProgress, 
+			long resourceMgmt, long avType, long mrMode, long mrKeySize, long cqDataSize, long cqCnt, 
+			long endpointCount, long txCtxCnt, long rxCtxCnt, long maxEpTxCtx, long maxEpRxCtx, long maxEpStxCtx, long maxEpSrxCtx);
 	
 	public DomainAttr() {
 		this.handle = initEmpty();
@@ -99,60 +99,55 @@ public class DomainAttr {
 	}
 	private native MRMode getMRMode(long handle);
 	
-	public int getMrKeySize() {
+	public long getMrKeySize() {
 		return getMrKeySize(this.handle);
 	}
-	private native int getMrKeySize(long handle);
+	private native long getMrKeySize(long handle);
 	
-	public int getCQDataSize() {
+	public long getCQDataSize() {
 		return getCQDataSize(this.handle);
 	}
-	private native int getCQDataSize(long handle);
+	private native long getCQDataSize(long handle);
 	
-	public int getCQCnt() {
+	public long getCQCnt() {
 		return getCQCnt(this.handle);
 	}
-	private native int getCQCnt(long handle);
+	private native long getCQCnt(long handle);
 	
-	public int getEndPointCnt() {
+	public long getEndPointCnt() {
 		return getEndPointCnt(handle);
 	}
+	private native long getEndPointCnt(long handle);
 	
-	private native int getEndPointCnt(long handle);
-	
-	public int getTxCtxCnt() {
+	public long getTxCtxCnt() {
 		return getTxCtxCnt(handle);
 	}
+	private native long getTxCtxCnt(long handle);
 	
-	private native int getTxCtxCnt(long handle);
-	
-	public int getRxCtxCnt() {
+	public long getRxCtxCnt() {
 		return getRxCtxCnt(handle);
 	}
+	private native long getRxCtxCnt(long handle);
 	
-	private native int getRxCtxCnt(long handle);
-	
-	public int getMaxEpTxCtx() {
+	public long getMaxEpTxCtx() {
 		return getMaxEpTxCtx(handle);
 	}
+	private native long getMaxEpTxCtx(long handle);
 	
-	private native int getMaxEpTxCtx(long handle);
-	
-	public int getMaxEpRxCtx() {
+	public long getMaxEpRxCtx() {
 		return getMaxEpRxCtx(handle);
 	}
+	private native long getMaxEpRxCtx(long handle);
 	
-	private native int getMaxEpRxCtx(long handle);
-	
-	public int getMaxEpStxCtx() {
+	public long getMaxEpStxCtx() {
 		return getMaxEpStxCtx(this.handle);
 	}
-	private native int getMaxEpStxCtx(long handle);
+	private native long getMaxEpStxCtx(long handle);
 	
-	public int getMaxEpSrxCtx() {
+	public long getMaxEpSrxCtx() {
 		return getMaxEpSrxCtx(this.handle);
 	}
-	private native int getMaxEpSrxCtx(long handle);
+	private native long getMaxEpSrxCtx(long handle);
 	
 	//sets
 	public void setName(String name) {
@@ -163,80 +158,80 @@ public class DomainAttr {
 	public void setThreading(Threading threading) {
 		setThreading(threading.getVal(), this.handle);
 	}
-	private native void setThreading(int threading, long handle);
+	private native void setThreading(long threading, long handle);
 	
 	public void setCntrlProgress(Progress cntrlProgress) {
 		setCntrlProgress(cntrlProgress.getVal(), this.handle);
 	}
-	private native void setCntrlProgress(int cntrlProgress, long handle);
+	private native void setCntrlProgress(long cntrlProgress, long handle);
 	
 	public void setDataProgress(Progress dataProgress) {
 		setDataProgress(dataProgress.getVal(), this.handle);
 	}
-	private native void setDataProgress(int dataProgress, long handle);
+	private native void setDataProgress(long dataProgress, long handle);
 	
 	public void setResourceMgmt(ResourceMgmt resourceMgmt) {
 		setResourceMgmt(resourceMgmt.getVal(), this.handle);
 	}
-	private native void setResourceMgmt(int resourceMgmt, long handle);
+	private native void setResourceMgmt(long resourceMgmt, long handle);
 	
 	public void setAVType(AVType avType) {
 		setAVType(avType.getVal(), this.handle);
 	}
-	private native void setAVType(int avType, long handle);
+	private native void setAVType(long avType, long handle);
 	
 	public void setMRMode(MRMode mrMode) {
 		setMRMode(mrMode.getVal(), this.handle);
 	}
-	private native void setMRMode(int mrMode, long handle);
+	private native void setMRMode(long mrMode, long handle);
 	
-	public void setMRKeySize(int mrKeySize) {
+	public void setMRKeySize(long mrKeySize) {
 		setMRKeySize(mrKeySize, this.handle);
 	}
-	private native void setMRKeySize(int mrKeySize, long handle);
+	private native void setMRKeySize(long mrKeySize, long handle);
 	
-	public void setCQDataSize(int cqDataSize) {
+	public void setCQDataSize(long cqDataSize) {
 		setCQDataSize(cqDataSize, this.handle);
 	}
-	private native void setCQDataSize(int mrKeySize, long handle);
+	private native void setCQDataSize(long mrKeySize, long handle);
 	
-	public void setCQCnt(int cqCnt) {
+	public void setCQCnt(long cqCnt) {
 		setCQCnt(cqCnt, this.handle);
 	}
-	private native void setCQCnt(int cqCnt, long handle);
+	private native void setCQCnt(long cqCnt, long handle);
 	
-	public void setEndpointCnt(int endpointCnt) {
+	public void setEndpointCnt(long endpointCnt) {
 		setEndpointCnt(endpointCnt, this.handle);
 	}
-	private native void setEndpointCnt(int endpointCnt, long handle);
+	private native void setEndpointCnt(long endpolongCnt, long handle);
 	
-	public void setTxCtxCnt(int txCtxCnt) {
+	public void setTxCtxCnt(long txCtxCnt) {
 		setTxCtxCnt(txCtxCnt, this.handle);
 	}
-	private native void setTxCtxCnt(int txCtxCnt, long handle);
+	private native void setTxCtxCnt(long txCtxCnt, long handle);
 	
-	public void setRxCtxCnt(int rxCtxCnt) {
+	public void setRxCtxCnt(long rxCtxCnt) {
 		setRxCtxCnt(rxCtxCnt, this.handle);
 	}
-	private native void setRxCtxCnt(int rxCtxCnt, long handle);
+	private native void setRxCtxCnt(long rxCtxCnt, long handle);
 	
-	public void setMaxEpTxCtx(int maxEpTxCtx) {
+	public void setMaxEpTxCtx(long maxEpTxCtx) {
 		setMaxEpTxCtx(maxEpTxCtx, this.handle);
 	}
-	private native void setMaxEpTxCtx(int maxEpTxCtx, long handle);
+	private native void setMaxEpTxCtx(long maxEpTxCtx, long handle);
 	
-	public void setMaxEpRxCtx(int maxEpRxCtx) {
+	public void setMaxEpRxCtx(long maxEpRxCtx) {
 		setMaxEpRxCtx(maxEpRxCtx, this.handle);
 	}
-	private native void setMaxEpRxCtx(int maxEpRxCtx, long handle);
+	private native void setMaxEpRxCtx(long maxEpRxCtx, long handle);
 	
-	public void setMaxEpStxCtx(int maxEpStxCtx) {
+	public void setMaxEpStxCtx(long maxEpStxCtx) {
 		setMaxEpStxCtx(maxEpStxCtx, this.handle);
 	}
-	private native void setMaxEpStxCtx(int maxEpStxCtx, long handle);
+	private native void setMaxEpStxCtx(long maxEpStxCtx, long handle);
 	
-	public void setMaxEpSrxCtx(int maxEpSrxCtx) {
+	public void setMaxEpSrxCtx(long maxEpSrxCtx) {
 		setMaxEpSrxCtx(maxEpSrxCtx, this.handle);
 	}
-	private native void setMaxEpSrxCtx(int maxEpSrxCtx, long handle);
+	private native void setMaxEpSrxCtx(long maxEpSrxCtx, long handle);
 }

--- a/src/main/native/org/ofi/libjfabric_native/constant.c
+++ b/src/main/native/org/ofi/libjfabric_native/constant.c
@@ -51,4 +51,5 @@ JNIEXPORT void JNICALL Java_org_ofi_libjfabric_Constant_setConstant
 	setLongField(env, c, jthis, "FI_MSG", FI_MSG);
 	setLongField(env, c, jthis, "FI_TRANSMIT", FI_TRANSMIT);
 	setLongField(env, c, jthis, "FI_RECV", FI_RECV);
+	setLongField(env, c, jthis, "FI_SEND", FI_RECV);
 }

--- a/src/main/native/org/ofi/libjfabric_native/domain.c
+++ b/src/main/native/org/ofi/libjfabric_native/domain.c
@@ -54,17 +54,34 @@ JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Domain_epOpen
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Domain_epOpen
 	(JNIEnv *env, jobject jthis, jlong domHandle, jlong infoHandle)
 {
-struct fid_ep *endPoint = (struct fid_ep *)calloc(1, sizeof(struct fid_ep));
+	struct fid_ep *endPoint = (struct fid_ep *)calloc(1, sizeof(struct fid_ep));
 
-ep_list[ep_list_tail] = endPoint;
-ep_list_tail++;
+	ep_list[ep_list_tail] = endPoint;
+	ep_list_tail++;
 
-int res = ((struct fid_domain *)domHandle)->ops->endpoint((struct fid_domain *)domHandle,
-		(struct fi_info *)infoHandle, &endPoint, NULL);
+	int res = ((struct fid_domain *)domHandle)->ops->endpoint((struct fid_domain *)domHandle,
+			(struct fi_info *)infoHandle, &endPoint, NULL);
 
-if(res) {
-	printf("Error opening endPoint: %d\n", res);
-	exit(1);
+	if(res) {
+		printf("Error opening endPoint: %d\n", res);
+		exit(1);
+	}
+	return (jlong)endPoint;
 }
-return (jlong)endPoint;
+
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_Domain_mrRegister
+	(JNIEnv *env, jobject jthis, jlong domHandle, jobject buf, jlong length, jlong access, jlong requestedKey)
+{
+	void *ptr = getDirectBufferAddress(env, buffer);
+	
+	struct fid_mr *mr; //TODO: A place for memory management code (not adding now because I will just do the free manually).
+	
+	int res = ((struct fid_domain *)domHandle)->mr->reg((struct fid_domain *)domHandle, ptr, length, access, 0, 
+			requestedKey, 0, &mr, NULL);
+	
+	if(res) {
+		printf("Error registering memory region: %d\n", res);
+		exit(1);
+	}
+	return (jlong)mr;
 }

--- a/src/main/native/org/ofi/libjfabric_native/domain_attr.c
+++ b/src/main/native/org/ofi/libjfabric_native/domain_attr.c
@@ -34,10 +34,10 @@
 #include "libfabric.h"
 
 JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_initDomainAttr
-(JNIEnv *env, jobject jthis, jstring name, jint jthreading, jint jcntrlProgress, jint jdataProgress,
-		jint jresourceMgmt, jint javType, jint jmrMode, jint jmrKeySize, jint jcqDataSize, jint jcqCnt,
-		jint jepCnt, jint jtxCtxCnt, jint jrxCtxCnt, jint jmaxEpTxCtx, jint jmaxEpRxCtx,
-		jint jmaxEpStxCtx, jint jmaxEpSrxCtx)
+(JNIEnv *env, jobject jthis, jstring name, jlong jthreading, jlong jcntrlProgress, jlong jdataProgress,
+		jlong jresourceMgmt, jlong javType, jlong jmrMode, jlong jmrKeySize, jlong jcqDataSize, jlong jcqCnt,
+		jlong jepCnt, jlong jtxCtxCnt, jlong jrxCtxCnt, jlong jmaxEpTxCtx, jlong jmaxEpRxCtx,
+		jlong jmaxEpStxCtx, jlong jmaxEpSrxCtx)
 {
 	struct fi_domain_attr *domain_attr = (struct fi_domain_attr*)calloc(1, sizeof(struct fi_domain_attr));
 
@@ -82,100 +82,100 @@ JNIEXPORT jstring JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getName
 JNIEXPORT jobject JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getThreading
 (JNIEnv *env, jobject jthis, jlong handle)
 {
-	int threading = ((struct fi_domain_attr*)handle)->threading;
+	long threading = ((struct fi_domain_attr*)handle)->threading;
 	return (*env)->CallObjectMethod(env, lib_globals.ThreadingClass, lib_globals.GetThreading, threading);
 }
 
 JNIEXPORT jobject JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getCntrlProgress
 (JNIEnv *env, jobject jthis, jlong handle)
 {
-	int cntrlProgress = ((struct fi_domain_attr*)handle)->control_progress;
+	long cntrlProgress = ((struct fi_domain_attr*)handle)->control_progress;
 	return (*env)->CallObjectMethod(env, lib_globals.ProgressClass, lib_globals.GetProgress, cntrlProgress);
 }
 
 JNIEXPORT jobject JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getdataProgress
 (JNIEnv *env, jobject jthis, jlong handle)
 {
-	int dataProgress = ((struct fi_domain_attr*)handle)->data_progress;
+	long dataProgress = ((struct fi_domain_attr*)handle)->data_progress;
 	return (*env)->CallObjectMethod(env, lib_globals.ProgressClass, lib_globals.GetProgress, dataProgress);
 }
 
 JNIEXPORT jobject JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getResourceMgmt
 (JNIEnv *env, jobject jthis, jlong handle)
 {
-	int resourceMgmt = ((struct fi_domain_attr*)handle)->resource_mgmt;
+	long resourceMgmt = ((struct fi_domain_attr*)handle)->resource_mgmt;
 	return (*env)->CallObjectMethod(env, lib_globals.ResourceMgmtClass, lib_globals.GetResourceMgmt, resourceMgmt);
 }
 
 JNIEXPORT jobject JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getAVType
 (JNIEnv *env, jobject jthis, jlong handle)
 {
-	int avType = ((struct fi_domain_attr*)handle)->av_type;
+	long avType = ((struct fi_domain_attr*)handle)->av_type;
 	return (*env)->CallObjectMethod(env, lib_globals.AVTypeClass, lib_globals.GetAVType, avType);
 }
 
 JNIEXPORT jobject JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMRMode
 (JNIEnv *env, jobject jthis, jlong handle)
 {
-	int mrMode = ((struct fi_domain_attr*)handle)->mr_mode;
+	long mrMode = ((struct fi_domain_attr*)handle)->mr_mode;
 	return (*env)->CallObjectMethod(env, lib_globals.MRModeClass, lib_globals.GetMRMode, mrMode);
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMrKeySize
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMrKeySize
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->mr_key_size;
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getCQDataSize
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getCQDataSize
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->cq_data_size;
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getCQCnt
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getCQCnt
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->cq_cnt;
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getEndPointCnt
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getEndPointCnt
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->ep_cnt;
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getTxCtxCnt
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getTxCtxCnt
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->tx_ctx_cnt;
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getRxCtxCnt
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getRxCtxCnt
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->rx_ctx_cnt;
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMaxEpTxCtx
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMaxEpTxCtx
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->max_ep_tx_ctx;
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMaxEpRxCtx
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMaxEpRxCtx
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->max_ep_rx_ctx;
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMaxEpStxCtx
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMaxEpStxCtx
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->max_ep_stx_ctx;
 }
 
-JNIEXPORT jint JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMaxEpSrxCtx
+JNIEXPORT jlong JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_getMaxEpSrxCtx
 (JNIEnv *env, jobject jthis, jlong handle)
 {
 	return ((struct fi_domain_attr*)handle)->max_ep_srx_ctx;
@@ -188,97 +188,97 @@ JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setName
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setThreading
-(JNIEnv *env, jobject jthis, jint jthreading, jlong handle)
+(JNIEnv *env, jobject jthis, jlong jthreading, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->threading = jthreading;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setCntrlProgress
-(JNIEnv *env, jobject jthis, jint cntrlProgress, jlong handle)
+(JNIEnv *env, jobject jthis, jlong cntrlProgress, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->control_progress = cntrlProgress;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setDataProgress
-(JNIEnv *env, jobject jthis, jint dataProgress, jlong handle)
+(JNIEnv *env, jobject jthis, jlong dataProgress, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->data_progress = dataProgress;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setResourceMgmt
-(JNIEnv *env, jobject jthis, jint resourceMgmt, jlong handle)
+(JNIEnv *env, jobject jthis, jlong resourceMgmt, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->resource_mgmt = resourceMgmt;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setAVType
-(JNIEnv *env, jobject jthis, jint avType, jlong handle)
+(JNIEnv *env, jobject jthis, jlong avType, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->av_type = avType;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setMRMode
-(JNIEnv *env, jobject jthis, jint mrMode, jlong handle)
+(JNIEnv *env, jobject jthis, jlong mrMode, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->mr_mode = mrMode;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setMRKeySize
-(JNIEnv *env, jobject jthis, jint mrKeySize, jlong handle)
+(JNIEnv *env, jobject jthis, jlong mrKeySize, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->mr_key_size = mrKeySize;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setCQDataSize
-(JNIEnv *env, jobject jthis, jint cqDataSize, jlong handle)
+(JNIEnv *env, jobject jthis, jlong cqDataSize, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->cq_data_size = cqDataSize;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setCQCnt
-(JNIEnv *env, jobject jthis, jint cqCnt, jlong handle)
+(JNIEnv *env, jobject jthis, jlong cqCnt, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->cq_cnt = cqCnt;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setEndpointCnt
-(JNIEnv *env, jobject jthis, jint endpointCnt, jlong handle)
+(JNIEnv *env, jobject jthis, jlong endpointCnt, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->ep_cnt = endpointCnt;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setTxCtxCnt
-(JNIEnv *env, jobject jthis, jint txCtxCnt, jlong handle)
+(JNIEnv *env, jobject jthis, jlong txCtxCnt, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->tx_ctx_cnt = txCtxCnt;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setRxCtxCnt
-(JNIEnv *env, jobject jthis, jint rxCtxCnt, jlong handle)
+(JNIEnv *env, jobject jthis, jlong rxCtxCnt, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->rx_ctx_cnt = rxCtxCnt;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setMaxEpTxCtx
-(JNIEnv *env, jobject jthis, jint maxEpTxCtx, jlong handle)
+(JNIEnv *env, jobject jthis, jlong maxEpTxCtx, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->max_ep_tx_ctx = maxEpTxCtx;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setMaxEpRxCtx
-(JNIEnv *env, jobject jthis, jint maxEpRxCtx, jlong handle)
+(JNIEnv *env, jobject jthis, jlong maxEpRxCtx, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->max_ep_rx_ctx = maxEpRxCtx;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setMaxEpStxCtx
-(JNIEnv *env, jobject jthis, jint maxEpStxCtx, jlong handle)
+(JNIEnv *env, jobject jthis, jlong maxEpStxCtx, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->max_ep_stx_ctx = maxEpStxCtx;
 }
 
 JNIEXPORT void JNICALL Java_org_ofi_libjfabric_attributes_DomainAttr_setMaxEpSrxCtx
-(JNIEnv *env, jobject jthis, jint maxEpSrxCtx, jlong handle)
+(JNIEnv *env, jobject jthis, jlong maxEpSrxCtx, jlong handle)
 {
 	((struct fi_domain_attr*)handle)->max_ep_srx_ctx = maxEpSrxCtx;
 }


### PR DESCRIPTION
Added the ability to register a memory region to the Domain
object.  I also fixed an issue in DomainAttr where there
were numerous ints which should have been longs. Added
another constant that was needed.

This commit also includes changes to the ping pong test
which prompted the changes to the java bindings.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
