### PR TITLE
Added the shutdown method to EndPoint

### DIFF
--- a/src/main/java/org/ofi/libjfabric/EndPoint.java
+++ b/src/main/java/org/ofi/libjfabric/EndPoint.java
@@ -105,4 +105,9 @@ public class EndPoint extends EndPointSharedOps {
 		sendMessage(this.handle, message.getHandle(), flags);
 	}
 	private native void sendMessage(long epHandle, long msgHandle, long flags);
+	
+	public void shutdown(long flags) {
+		shutdown(this.handle, flags);
+	}
+	private native void shutdown(long handle, long flags);
 }

--- a/src/main/native/org/ofi/libjfabric_native/endpoint.c
+++ b/src/main/native/org/ofi/libjfabric_native/endpoint.c
@@ -102,3 +102,9 @@ JNIEXPORT void JNICALL Java_org_ofi_libjfabric_EndPoint_sendMessage
 {
 	((struct fid_ep *)epHandle)->msg->sendmsg((struct fid_ep *)epHandle, (const struct fi_msg *)msgHandle, flags);
 }
+
+JNIEXPORT void JNICALL Java_org_ofi_libjfabric_EndPoint_shutdown
+	(JNIEnv *env, jobject jthis, jlong handle, jlong flags)
+{
+	((struct fid_ep *)handle)->cm->shutdown((struct fid_ep *)handle, flags);
+}

--- a/src/test/java/org/ofi/libjfabrictests/PingPongTest.java
+++ b/src/test/java/org/ofi/libjfabrictests/PingPongTest.java
@@ -1289,9 +1289,9 @@ int pp_cq_readerr(struct fid_cq *cq)
 
 		run_suite_pingpong(ct);
 
-		//pp_finalize(ct); //TODO:HERE
+		pp_finalize(ct); //TODO:HERE
 
-		//fi_shutdown(ct->ep, 0);
+		ct.ep.shutdown(0);
 	}
 
 


### PR DESCRIPTION
This commit adds the shutdown method to EndPoint.

It also includes the changes to PingPongTest.java
that prompted the changes to the Java bindings.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
